### PR TITLE
feat: support multiple choice questions without JS

### DIFF
--- a/src/css/components/_switcher.scss
+++ b/src/css/components/_switcher.scss
@@ -2,14 +2,13 @@
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;
-}
 
-.cmp-switcher > * {
-  flex-grow: 1;
-  flex-basis: calc((30rem - 100%) * 999);
-}
+  > * {
+    flex-grow: 1;
+    flex-basis: calc((30rem - 100%) * 999);
+  }
 
-.cmp-switcher > :nth-last-child(n + 5),
-.cmp-switcher > :nth-last-child(n + 5) ~ * {
-  flex-basis: 100%;
+  &__full-width {
+    flex-basis: 100%;
+  }
 }

--- a/src/css/generic/_no-js.scss
+++ b/src/css/generic/_no-js.scss
@@ -1,0 +1,11 @@
+.no-js {
+  [data-needs-js] {
+    display: none;
+  }
+}
+
+.js {
+  [data-no-js] {
+    display: none;
+  }
+}

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -44,17 +44,18 @@
 //    the site. This section should include any Reset or Normalize libraries
 //    and any preferential base styles for elements. There shouldn't be any
 //    classes or ids used in this section.
-@forward "generic/reset";
+@forward 'generic/reset';
+@forward 'generic/no-js';
 
 // =====================================================================
 // 4. Elements
 //    Styling for bare HTML elements (like H1, A, etc.). These come with
 //    default styling from the browser so we can redefine them here.
-@forward "elements/root";
-@forward "elements/body";
-@forward "elements/a";
-@forward "elements/p";
-@forward "elements/header";
+@forward 'elements/root';
+@forward 'elements/body';
+@forward 'elements/a';
+@forward 'elements/p';
+@forward 'elements/header';
 
 // =====================================================================
 // 5. Objects
@@ -65,14 +66,14 @@
 // 6. Components
 //    Specific UI components. This is where majority of our work takes place
 //    and our UI components are often composed of Objects and Components
-@forward "components/container";
-@forward "components/stack";
-@forward "components/switcher";
-@forward "components/pagination";
-@forward "components/question";
-@forward "components/answer";
-@forward "components/categories";
-@forward "components/option";
+@forward 'components/container';
+@forward 'components/stack';
+@forward 'components/switcher';
+@forward 'components/pagination';
+@forward 'components/question';
+@forward 'components/answer';
+@forward 'components/categories';
+@forward 'components/option';
 
 // =====================================================================
 // 7. Vendors (Optional)

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -25,6 +25,11 @@
     <link rel="stylesheet" href="https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed/font.css">
     <link rel="stylesheet" href="https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed-italic/font.css">
     <link rel="stylesheet" href="/styles.css">
+
+    <script>
+      document.documentElement.classList.remove('no-js');
+      document.documentElement.classList.add('js');
+    </script>
   </head>
   <body>
     {% block header %}

--- a/src/macros/multiple-choice.njk
+++ b/src/macros/multiple-choice.njk
@@ -4,7 +4,7 @@
   </div>
   <div class="cmp-switcher">
     {% for option in question.options %}
-      <div>
+      <div data-needs-js>
         <button type="button" class="cmp-option-button" aria-pressed="false" aria-describedby="option-{{ loop.index }}" data-correct="{{ option.isCorrect }}">
           {% if loop.index === 1 %}
             A
@@ -17,6 +17,34 @@
         <div id="option-{{ loop.index }}">
           {{ option.answer | mdToHtml | safe }}
         </div>
+      </div>
+      <div data-no-js class="cmp-switcher__full-width">
+        <div id="no-js-option-{{ loop.index }}">
+          {{ option.answer | mdToHtml | safe }}
+        </div>
+        <details class="cmp-answer">
+          <summary aria-describedby="no-js-option-{{ loop.index }}">
+            {% if loop.index === 1 %}
+              A
+            {% elseif loop.index === 2 %}
+              B
+            {% else %}
+              C
+            {% endif %}
+          </summary>
+          <div>
+            <p>
+              {% if option.isCorrect %}
+                Correct
+              {% else %}
+                Incorrect
+              {% endif %}
+            </p>
+            {% if question.Explanation %}
+              {{ question.Explanation | mdToHtml | safe }}
+            {% endif %}
+          </div>
+        </details>
       </div>
     {% endfor %}
   </div>

--- a/src/macros/multiple-choice.njk
+++ b/src/macros/multiple-choice.njk
@@ -19,9 +19,6 @@
         </div>
       </div>
       <div data-no-js class="cmp-switcher__full-width">
-        <div id="no-js-option-{{ loop.index }}">
-          {{ option.answer | mdToHtml | safe }}
-        </div>
         <details class="cmp-answer">
           <summary aria-describedby="no-js-option-{{ loop.index }}">
             {% if loop.index === 1 %}
@@ -45,6 +42,9 @@
             {% endif %}
           </div>
         </details>
+        <div id="no-js-option-{{ loop.index }}">
+          {{ option.answer | mdToHtml | safe }}
+        </div>
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work provides a fallback method for multiple choice questions in the event of JS being disabled. It uses the Modernizr technique of toggling a `no-js` class on the `html` tag to `js`, which affects which elements are displayed. In this case, that means `details`/`summary` elements representing each answer. If JS is supported, those are hidden and the buttons are shown instead.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Disable JavaScript in your browser's Dev Tools
5. Click/tab through the multiple choice questions, making sure the `details`/`summary` flow functions while still feeling like multiple choice
6. Re-enable JS in your browser, and go through the same questions, making sure there's no flash of unstyled content or noticeable swapping between methods, and that the button implementation still works as expected
<!-- Add additional validation steps here -->
