### PR TITLE
feat: support no-JS multiple choice questions

### DIFF
--- a/src/css/components/_multiple-choice.scss
+++ b/src/css/components/_multiple-choice.scss
@@ -12,7 +12,8 @@
 		align-items: stretch;
 	}
 
-	&__button {
+	&__button,
+	&__summary {
 		position: absolute;
 		inset: 0;
 		z-index: 200;
@@ -91,6 +92,19 @@
 		@media (prefers-color-scheme: dark) {
 			background-color: var(--foundry-culture-accent-dark);
 			border-color: var(--brand-turquoise);
+		}
+	}
+
+	.no-js & {
+		flex-direction: column;
+
+		&__item[data-no-js] {
+			display: block;
+
+		}
+
+		&__summary {
+			list-style: none;
 		}
 	}
 }

--- a/src/css/generic/_no-js.scss
+++ b/src/css/generic/_no-js.scss
@@ -1,0 +1,11 @@
+.no-js {
+  [data-needs-js] {
+    display: none;
+  }
+}
+
+.js {
+  [data-no-js] {
+    display: none;
+  }
+}

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -45,6 +45,7 @@
 //    and any preferential base styles for elements. There shouldn't be any
 //    classes or ids used in this section.
 @forward "generic/reset";
+@forward "generic/no-js";
 
 // =====================================================================
 // 4. Elements

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -39,6 +39,10 @@
         gtag('config', 'G-YWPK6PY9PL');
       </script>
     {% endif %}
+    <script>
+      document.documentElement.classList.remove('no-js');
+      document.documentElement.classList.add('js');
+    </script>
   </head>
   <body>
     <div class="obj-page">

--- a/src/macros/multiple-choice.njk
+++ b/src/macros/multiple-choice.njk
@@ -4,11 +4,31 @@
   </div>
   <div class="cmp-multiple-choice">
     {% for option in question.options %}
-      <div class="cmp-multiple-choice__item">
+      <div class="cmp-multiple-choice__item" data-needs-js>
         <button type="button" class="cmp-multiple-choice__button js-multiple-choice" aria-labelledby="option-{{ loop.index }}" aria-pressed="false" data-correct="{{ option.isCorrect }}"></button>
         <div class="cmp-multiple-choice__answer" id="option-{{ loop.index }}" aria-hidden="true">
           {{ option.answer | mdToHtml | safe }}
         </div>
+      </div>
+      <div class="cmp-multiple-choice__item" data-no-js>
+        <div id="no-js-option-{{ loop.index }}" class="cmp-multiple-choice__answer" aria-hidden="true">
+          {{ option.answer | mdToHtml | safe }}
+        </div>
+        <details>
+          <summary class="cmp-multiple-choice__summary" aria-labelledby="no-js-option-{{ loop.index }}"></summary>
+          <div class="cmp-explanation-section">
+            <h3 class="cmp-explanation-section__title cmp-explanation-section__title--{% if option.isCorrect %}correct{% else %}incorrect{% endif %}">
+              {% if option.isCorrect %}
+                Correct
+              {% else %}
+                Incorrect
+              {% endif %}
+            </h3>
+            {% if question.Explanation %}
+              {{ question.Explanation | mdToHtml | safe }}
+            {% endif %}
+          </div>
+        </details>
       </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This is a reworked implementation of #48 that works with the new design changes. It uses `details`/`summary` elements as fallbacks for when JS is disabled, and it uses a Modernizr-type strategy to toggle `no-js` to `js` in an `html` element class so we can style things differently depending on if JS is available.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. With JS enabled, go through multiple choice questions, making sure they still work as expected
5. In dev tools, disable JavaScript, and go through the same questions, making sure you can still select answers and see if you chose correctly
<!-- Add additional validation steps here -->
