### PR TITLE
fix: prevent empty choices from showing up in multiple choice

### DIFF
--- a/pages/_data/questionData.js
+++ b/pages/_data/questionData.js
@@ -24,14 +24,14 @@ const getQuestions = async () => {
         },
       ];
 
-      if (record.fields['Distractor 1']) {
+      if (record.fields['Distractor 1']?.trim()) {
         options.push({
           answer: record.fields['Distractor 1'],
           isCorrect: false,
         });
       }
 
-      if (record.fields['Distractor 2']) {
+      if (record.fields['Distractor 2']?.trim()) {
         options.push({
           answer: record.fields['Distractor 2'],
           isCorrect: false,


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->

This fixes an issue where empty space in Airtable data for distractors could lead to blank options showing up in multiple choice questions.

Closes #51 

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Navigate through the multiple choice questions, making sure none of them have blank options as described in #51 (it was caught in Guidelines and Specifications)
<!-- Add additional validation steps here -->
