### PR TITLE
feat: set up SEO and analytics

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,8 @@
+[build.environment]
+  NODE_ENV = ""
+[context.dev.environment]
+  NODE_ENV = "development"
+[context.deploy-preview.environment]
+  NODE_ENV = "preview"
+[context.production.environment]
+  NODE_ENV = "production"

--- a/pages/_data/processEnv.js
+++ b/pages/_data/processEnv.js
@@ -3,4 +3,5 @@ require('dotenv').config();
 
 module.exports = {
   BASE_URL: process.env.BASE_URL,
+  NODE_ENV: process.env.NODE_ENV,
 };

--- a/pages/index.njk
+++ b/pages/index.njk
@@ -1,6 +1,6 @@
 ---
 title: Home
-description: Choose a category to test your accessibility knowledge in.
+description: Choose a category to test your web accessibility knowledge in. This quiz is brought to you by Sparkbox.
 layout: default
 ---
 

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -28,9 +28,17 @@
     <link rel="stylesheet" href="https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed-italic/font.css">
     <link rel="stylesheet" href="/styles.css">
 
-    <script>
-      console.log({ environment: '{{ processEnv.NODE_ENV }}' })
-    </script>
+    {% if processEnv.NODE_ENV === 'production' %}
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-YWPK6PY9PL"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'G-YWPK6PY9PL');
+      </script>
+    {% endif %}
   </head>
   <body>
     <div class="obj-page">

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% block titleAndDescription %}
-    <title>{{ title }} | Trivia11y</title>
+    <title>{{ title }} | Trivia11y: A Web Accessibility Quiz</title>
     <meta name="description" content="{{ description }}">
     {% endblock %}
 

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -27,6 +27,10 @@
     <link rel="stylesheet" href="https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed/font.css">
     <link rel="stylesheet" href="https://assets.sparkbox.com/fonts/sole/sole-sans-vf-regular-extra-condensed-italic/font.css">
     <link rel="stylesheet" href="/styles.css">
+
+    <script>
+      console.log({ environment: '{{ processEnv.NODE_ENV }}' })
+    </script>
   </head>
   <body>
     <div class="obj-page">


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work makes the following analytics and SEO updates:
- Sets up context-specific `NODE_ENV` variables to distinguish environments
- Loads Google Tag Manager in production
- Updates the `title` to include more info
- Updates the home page's description to include a little more context

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Go to the home page and verify that the `title` and meta description updates are valid
5. Confirm that the GTM script does not get loaded
6. Stop the local server and set `NODE_ENV=production` in your `.env` file
7. Run `npm start` again and confirm this time that the GTM script does load
8. As cleanup, delete the `NODE_ENV` variable from your `.env` file or change it to "development"
9. Confirm that the deploy preview does not load the GTM script
<!-- Add additional validation steps here -->
