### PR TITLE
feat: styling adjustments

### DIFF
--- a/src/css/components/_answer.scss
+++ b/src/css/components/_answer.scss
@@ -1,8 +1,12 @@
+@use "../tools/text-outline" as text;
+
 .cmp-answer {
   margin-block: 1.5rem;
   font-size: clamp(1rem, 1rem + 1vw, 2rem);
 
   &__reveal {
+    @include text.outline;
+
     cursor: pointer;
     margin-block: 1rem;
     text-decoration: underline;

--- a/src/css/components/_categories.scss
+++ b/src/css/components/_categories.scss
@@ -64,7 +64,10 @@
     &:hover::before,
     &:focus::before {
       opacity: 1;
-      animation: categories-rotate 2s linear infinite;
+
+      @media (prefers-reduced-motion: no-preference) {
+        animation: categories-rotate 2s linear infinite;
+      }
     }
 
     &:hover::after,

--- a/src/css/components/_categories.scss
+++ b/src/css/components/_categories.scss
@@ -13,6 +13,8 @@
   padding-inline: 2rem 0;
 
   &__link {
+    @include text.outline;
+
     position: relative;
     text-decoration: underline;
     text-underline-offset: 2px;

--- a/src/css/components/_header.scss
+++ b/src/css/components/_header.scss
@@ -44,7 +44,10 @@
 
 		&:hover{
 			color: var(--brand-pink);
-			transition-delay: 450ms;
+
+			@media (prefers-reduced-motion: no-preference) {
+				transition-delay: 450ms;
+			}
 		}
 
 		& > span {
@@ -58,12 +61,14 @@
 	}
 
 	&__nav-item:hover > span {
-		animation: pop 500ms ease-in-out forwards 1;
+		@media (prefers-reduced-motion: no-preference) {
+			animation: pop 500ms ease-in-out forwards 1;
 
-		@for $i from 1 through 8 {
-			$n: $i + 1;
-			&:nth-child(#{$n}) {
-				animation-delay: #{50ms * $i};
+			@for $i from 1 through 8 {
+				$n: $i + 1;
+				&:nth-child(#{$n}) {
+					animation-delay: #{50ms * $i};
+				}
 			}
 		}
 	}

--- a/src/css/components/_pagination.scss
+++ b/src/css/components/_pagination.scss
@@ -1,3 +1,5 @@
+@use "../tools/text-outline" as text;
+
 .cmp-pagination {
   display: flex;
   flex-flow: row-reverse wrap;
@@ -6,5 +8,7 @@
 }
 
 .cmp-pagination a {
+  @include text.outline;
+
   font-size: clamp(1rem, 1rem + 0.5vw, 1.5rem);
 }


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This adds support for reduced motion preferences and adds a drop shadow to text elements that were overlapping the background elements in a hard-to-read way.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Go to the home page and confirm the hover/focus states are animated for the Trivia11y link in the header and the home page category links
5. Change your OS system settings to Reduce Motion, then check that those animations are turned off
6. Confirm that text elements, including the category links on the home page, the pagination links, and the `summary` elements in Flash Cards question pages all have drop shadows that make them easier to read when overlapping with the background images
<!-- Add additional validation steps here -->
