### PR TITLE
feat: add custom page title for homepage with optional seo_title

### DIFF
--- a/pages/index.njk
+++ b/pages/index.njk
@@ -1,6 +1,7 @@
 ---
 title: Home
-description: Choose a category to test your web accessibility knowledge in. This quiz is brought to you by Sparkbox.
+seo_title: "Trivia11y: A Web Accessibility Quiz"
+description: A quiz game and study tool to help those at all skill levels to learn and test their accessibility knowledge. Flash cards, multiple choice, and short answer type of questions are available in multiple categories.
 layout: default
 ---
 

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -5,7 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% block titleAndDescription %}
-    <title>{{ title }} | Trivia11y: A Web Accessibility Quiz</title>
+    <title>
+      {%- if seo_title -%}
+        {{ seo_title }}
+      {%- else -%}
+        {{ title }} | Trivia11y: A Web Accessibility Quiz
+      {%- endif -%}
+    </title>
     <meta name="description" content="{{ description }}">
     {% endblock %}
 


### PR DESCRIPTION
## Description

Removes the home page page title beginning with "Home |".

Adds the ability to customize a page's full page title using `seo_title` and falls back to existing title template.

## To Validate


1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Make sure home page title does not display "Home |" at the start and matches the defined `seo_title`.
5. The other pages' titles remain unchanged, using existing template.
