### PR TITLE
fix: open graph image file extension mismatch

### DIFF
--- a/src/layout.njk
+++ b/src/layout.njk
@@ -22,7 +22,7 @@
     <link rel="apple-touch-icon" href="/maskable_icon.png">
     <link rel="manifest" href="/manifest.json">
 
-    <meta property="og:image" content="{{ processEnv.BASE_URL }}/og-image.jpg" />
+    <meta property="og:image" content="{{ processEnv.BASE_URL }}/og-image.png" />
 
     <meta name="color-scheme" content="light dark">
     <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)">


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
The open graph image was not loading because the file extension was for a JPEG, not a PNG.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Check the `head` for an open graph image whose URL ends in `.png`
<!-- Add additional validation steps here -->
