### PR TITLE
feat: improve mobile styles

### DIFF
--- a/src/css/components/_answer.scss
+++ b/src/css/components/_answer.scss
@@ -21,7 +21,7 @@
   }
 
   &__container {
-    padding: 3rem;
+    padding: clamp(1rem, 1rem + 1vw, 3rem);
     background-color: var(--background-color);
     border: 0.125rem solid currentcolor;
     border-radius: 0.25rem;

--- a/src/css/components/_multiple-choice.scss
+++ b/src/css/components/_multiple-choice.scss
@@ -56,6 +56,10 @@
 				margin-block-start: 0.5em;
 			}
 		}
+
+		> pre {
+			white-space: pre-wrap;
+		}
 	}
 
 	&__button:hover + &__answer {

--- a/src/css/components/_multiple-choice.scss
+++ b/src/css/components/_multiple-choice.scss
@@ -1,12 +1,13 @@
 .cmp-multiple-choice {
 	display: flex;
-	gap: 2rem;
+	gap: clamp(1rem, 1rem + 0.5vw, 2rem);
 	align-items: stretch;
 	margin-block: 2rem;
 	flex-wrap: wrap;
 
 	&__item {
-		flex: 1 1 calc(33% - 1.33rem);
+		flex-grow: 1;
+		flex-basis: calc((35rem - 100%) * 999);
 		position: relative;
 		display: flex;
 		align-items: stretch;
@@ -33,8 +34,6 @@
 	&__answer {
 		display: flex;
 		flex-basis: 100%;
-		justify-content: center;
-		align-items: center;
 		padding: 1rem;
 		background-color: var(--background-color);
 		color: inherit;

--- a/src/css/components/_question.scss
+++ b/src/css/components/_question.scss
@@ -1,5 +1,5 @@
 .cmp-question {
-  padding: 3rem;
+  padding: clamp(1rem, 1rem + 1vw,3rem);
   background-color: var(--background-color);
   border: 0.125rem solid currentcolor;
   border-radius: 0.25rem;


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work improves some awkward styling that happens on small screens:
- Decreases padding around questions and flash card answers on small screens
- Prevents most multiple choice answers from wrapping with one item on a line by itself (it still happens for answers with a lot of text, but this is fine for that case)
- Allows text in `pre` tags to wrap, fixing an overflow issue for a question with code sample answers

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed @jenndiaz 
2. Pull down this branch @jenndiaz 
3. Run `npm start` @jenndiaz 
4. Navigate to the equivalent local version of [this multiple choice question](https://trivia11y.com/multiple-choice/forms/1/) and confirm that on screens as small as 320px wide, the answers do not cause horizontal overflow @jenndiaz 
5. Go through a representative sample of multiple choice questions and confirm that the answers only wrap with one item on the last line when there is a lot of text in the answers and the screen size is in the tablet range @jenndiaz 
6. Check flash card question styles for a representative sample and make sure the padding is spacious without making the text awkwardly smushed on small screen sizes @jenndiaz 
<!-- Add additional validation steps here -->
