### PR TITLE
feat: randomize question order between builds

### DIFF
--- a/pages/all/flash-cards/index.njk
+++ b/pages/all/flash-cards/index.njk
@@ -23,7 +23,7 @@ eleventyExcludeFromCollections: true
   <article>
     <header class="cmp-game-header">
       <h1 class="cmp-game-header__title">All Categories</h1>
-      <h2 class="cmp-game-header__question-count">Question {{ pagination.pageNumber + 1 }} of {{ questionTotal }}</h2>
+      <h2 class="cmp-game-header__question-count">Question <span data-question-number>{{ pagination.pageNumber + 1 }}</span> of {{ questionTotal }}</h2>
     </header>
 
     {% from 'macros/flash-card.njk' import flashCard %}
@@ -31,7 +31,7 @@ eleventyExcludeFromCollections: true
 
     <div class="cmp-pagination">
       {% if questionTotal > pagination.pageNumber + 1 %}
-        <a href="/all/flash-cards/{{ pagination.pageNumber + 2 }}/">
+        <a href="/all/flash-cards/{{ pagination.pageNumber + 2 }}/" data-next-link>
           Next Question
         </a>
       {% else %}
@@ -39,7 +39,7 @@ eleventyExcludeFromCollections: true
       {% endif %}
 
       {% if pagination.pageNumber + 1 > 1 %}
-        <a href="/all/flash-cards/{{ pagination.pageNumber }}/">
+        <a href="/all/flash-cards/{{ pagination.pageNumber }}/" data-prev-link>
           Previous Question
         </a>
       {% else %}
@@ -48,4 +48,10 @@ eleventyExcludeFromCollections: true
     </div>
   </article>
 </div>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    {% include 'js/update-pagination-links.js' %}
+  </script>
 {% endblock %}

--- a/pages/all/multiple-choice/index.njk
+++ b/pages/all/multiple-choice/index.njk
@@ -23,7 +23,7 @@ eleventyExcludeFromCollections: true
   <article>
     <header class="cmp-game-header">
       <h1 class="cmp-game-header__title">All Categories</h1>
-      <h2 class="cmp-game-header__question-count">Question {{ pagination.pageNumber + 1 }} of {{ questionTotal }}</h2>
+      <h2 class="cmp-game-header__question-count">Question <span data-question-number>{{ pagination.pageNumber + 1 }}</span> of {{ questionTotal }}</h2>
     </header>
 
     {% from 'macros/multiple-choice.njk' import multipleChoice %}
@@ -31,7 +31,7 @@ eleventyExcludeFromCollections: true
 
     <div class="cmp-pagination">
       {% if questionTotal > pagination.pageNumber + 1 %}
-        <a href="/all/multiple-choice/{{ pagination.pageNumber + 2 }}/">
+        <a href="/all/multiple-choice/{{ pagination.pageNumber + 2 }}/" data-next-link>
           Next Question
         </a>
       {% else %}
@@ -39,7 +39,7 @@ eleventyExcludeFromCollections: true
       {% endif %}
 
       {% if pagination.pageNumber + 1 > 1 %}
-        <a href="/all/multiple-choice/{{ pagination.pageNumber }}/">
+        <a href="/all/multiple-choice/{{ pagination.pageNumber }}/" data-prev-link>
           Previous Question
         </a>
       {% else %}
@@ -53,5 +53,6 @@ eleventyExcludeFromCollections: true
 {% block scripts %}
   <script>
     {% include 'js/multiple-choice.js' %}
+    {% include 'js/update-pagination-links.js' %}
   </script>
 {% endblock %}

--- a/pages/all/short-answer/index.njk
+++ b/pages/all/short-answer/index.njk
@@ -23,7 +23,7 @@ eleventyExcludeFromCollections: true
     <article>
       <header class="cmp-game-header">
         <h1 class="cmp-game-header__title">All Categories</h1>
-        <h2 class="cmp-game-header__question-count">Question {{ pagination.pageNumber + 1 }} of {{ questionTotal }}</h2>
+      <h2 class="cmp-game-header__question-count">Question <span data-question-number>{{ pagination.pageNumber + 1 }}</span> of {{ questionTotal }}</h2>
       </header>
 
       {% from 'macros/short-answer.njk' import shortAnswer %}
@@ -31,7 +31,7 @@ eleventyExcludeFromCollections: true
 
       <div class="cmp-pagination">
         {% if questionTotal > pagination.pageNumber + 1 %}
-          <a href="/all/short-answer/{{ pagination.pageNumber + 2 }}/">
+          <a href="/all/short-answer/{{ pagination.pageNumber + 2 }}/" data-next-link>
             Next Question
           </a>
         {% else %}
@@ -39,7 +39,7 @@ eleventyExcludeFromCollections: true
         {% endif %}
 
         {% if pagination.pageNumber + 1 > 1 %}
-          <a href="/all/short-answer/{{ pagination.pageNumber }}/">
+          <a href="/all/short-answer/{{ pagination.pageNumber }}/" data-prev-link>
             Previous Question
           </a>
         {% else %}
@@ -53,5 +53,6 @@ eleventyExcludeFromCollections: true
 {% block scripts %}
   <script>
     {% include 'js/short-answer.js' %}
+    {% include 'js/update-pagination-links.js' %}
   </script>
 {% endblock %}

--- a/pages/flash-cards/index.njk
+++ b/pages/flash-cards/index.njk
@@ -22,14 +22,14 @@ eleventyExcludeFromCollections: true
   <article>
     <header class="cmp-game-header">
       <h1 class="cmp-game-header__title">Category: {{ questionGroup.category }}</h1>
-      <h2 class="cmp-game-header__question-count">Question {{ questionGroup.pageNumber }} of {{ questionGroup.questionTotal }}</h2>
+      <h2 class="cmp-game-header__question-count">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of {{ questionGroup.questionTotal }}</h2>
     </header>
     {% from 'macros/flash-card.njk' import flashCard %}
     {{ flashCard(questionGroup.question) }}
 
     <div class="cmp-pagination">
       {% if questionGroup.questionTotal > questionGroup.pageNumber %}
-        <a href="/flash-cards/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber + 1 }}/">
+        <a href="/flash-cards/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber + 1 }}/" data-next-link>
           Next Question
         </a>
       {% else %}
@@ -37,7 +37,7 @@ eleventyExcludeFromCollections: true
       {% endif %}
 
       {% if questionGroup.pageNumber > 1 %}
-        <a href="/flash-cards/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber - 1 }}/">
+        <a href="/flash-cards/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber - 1 }}/" data-prev-link>
           Previous Question
         </a>
       {% else %}
@@ -46,4 +46,10 @@ eleventyExcludeFromCollections: true
     </div>
   </article>
 </div>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    {% include 'js/update-pagination-links.js' %}
+  </script>
 {% endblock %}

--- a/pages/index.njk
+++ b/pages/index.njk
@@ -2,32 +2,41 @@
 title: Home
 seo_title: "Trivia11y: A Web Accessibility Quiz by Sparkbox"
 description: A quiz game and study tool to help those at all skill levels to learn and test their accessibility knowledge. Flash cards, multiple choice, and short answer questions are available in multiple categories.
-layout: default
 ---
 
-<div class="obj-width-limiter">
-	<h1>Test Your Accessibility Knowledge</h1>
+{% extends 'layout.njk' %}
 
-	<p class="util-limit-width">
-		Accessibility is important, but becoming an expert means taking the time to understand and memorize priorities, regulations, requirements, and techniques. So how can you determine whether you're up to speed? With games, of course!
-	</p>
+{% block content%}
+	<div class="obj-width-limiter">
+		<h1>Test Your Accessibility Knowledge</h1>
 
-	<h2>Game Types</h2>
+		<p class="util-limit-width">
+			Accessibility is important, but becoming an expert means taking the time to understand and memorize priorities, regulations, requirements, and techniques. So how can you determine whether you're up to speed? With games, of course!
+		</p>
 
-	<p class="util-limit-width">
-		Choose a game format and then select a category to help you test your knowledge: Flash Cards for reviewing what you know, Short Answer questions for confirming you actually know your stuff, and Multiple Choice for simulating test conditions.
-	</p>
+		<h2>Game Types</h2>
 
-	{% from 'macros/categories.njk' import categories %}
-	<div class="obj-game-type">
-		<div class="obj-game-type__group">
-			{{ categories('flash-cards', 'Flash Cards', questionData.flashCardCategories) }}
-		</div>
-    <div class="obj-game-type__group">
-			{{ categories('short-answer', 'Short Answer', questionData.flashCardCategories) }}
-		</div>
-		<div class="obj-game-type__group">
-			{{ categories('multiple-choice', 'Multiple Choice', questionData.categories) }}
+		<p class="util-limit-width">
+			Choose a game format and then select a category to help you test your knowledge: Flash Cards for reviewing what you know, Short Answer questions for confirming you actually know your stuff, and Multiple Choice for simulating test conditions.
+		</p>
+
+		{% from 'macros/categories.njk' import categories %}
+		<div class="obj-game-type">
+			<div class="obj-game-type__group">
+				{{ categories('flash-cards', 'Flash Cards', questionData.flashCardCategories) }}
+			</div>
+			<div class="obj-game-type__group">
+				{{ categories('short-answer', 'Short Answer', questionData.flashCardCategories) }}
+			</div>
+			<div class="obj-game-type__group">
+				{{ categories('multiple-choice', 'Multiple Choice', questionData.categories) }}
+			</div>
 		</div>
 	</div>
-</div>
+{% endblock %}
+
+{% block scripts %}
+	<script>
+		{% include 'js/intercept-category-navigation.js' %}
+	</script>
+{% endblock %}

--- a/pages/multiple-choice/index.njk
+++ b/pages/multiple-choice/index.njk
@@ -23,7 +23,7 @@ eleventyExcludeFromCollections: true
   <article>
     <header class="cmp-game-header">
       <h1 class="cmp-game-header__title">Category: {{ questionGroup.category }}</h1>
-      <h2 class="cmp-game-header__question-count">Question {{ questionGroup.pageNumber }} of {{ questionGroup.questionTotal }}</h2>
+      <h2 class="cmp-game-header__question-count">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of {{ questionGroup.questionTotal }}</h2>
     </header>
 
     {% from 'macros/multiple-choice.njk' import multipleChoice %}
@@ -31,7 +31,7 @@ eleventyExcludeFromCollections: true
 
     <div class="cmp-pagination">
       {% if questionGroup.questionTotal > questionGroup.pageNumber %}
-        <a href="/multiple-choice/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber + 1 }}/">
+        <a href="/multiple-choice/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber + 1 }}/" data-next-link>
           Next Question
         </a>
       {% else %}
@@ -39,7 +39,7 @@ eleventyExcludeFromCollections: true
       {% endif %}
 
       {% if questionGroup.pageNumber > 1 %}
-        <a href="/multiple-choice/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber - 1 }}/">
+        <a href="/multiple-choice/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber - 1 }}/" data-prev-link>
           Previous Question
         </a>
       {% else %}
@@ -53,5 +53,6 @@ eleventyExcludeFromCollections: true
 {% block scripts %}
   <script>
     {% include 'js/multiple-choice.js' %}
+    {% include 'js/update-pagination-links.js' %}
   </script>
 {% endblock %}

--- a/pages/questions.ejs
+++ b/pages/questions.ejs
@@ -1,0 +1,6 @@
+---
+permalink: /questions.json
+eleventyExcludeFromCollections: true
+---
+
+<%- JSON.stringify(questionData.questions) -%>

--- a/pages/short-answer/index.njk
+++ b/pages/short-answer/index.njk
@@ -22,7 +22,7 @@ eleventyExcludeFromCollections: true
     <article>
       <header class="cmp-game-header">
         <h1 class="cmp-game-header__title">Category: {{ questionGroup.category }}</h1>
-        <h2 class="cmp-game-header__question-count">Question {{ questionGroup.pageNumber }} of {{ questionGroup.questionTotal }}</h2>
+        <h2 class="cmp-game-header__question-count">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of {{ questionGroup.questionTotal }}</h2>
       </header>
 
       {% from 'macros/short-answer.njk' import shortAnswer %}
@@ -30,7 +30,7 @@ eleventyExcludeFromCollections: true
 
       <div class="cmp-pagination">
         {% if questionGroup.questionTotal > questionGroup.pageNumber %}
-          <a href="/short-answer/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber + 1 }}/">
+          <a href="/short-answer/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber + 1 }}/" data-next-link>
             Next Question
           </a>
         {% else %}
@@ -38,7 +38,7 @@ eleventyExcludeFromCollections: true
         {% endif %}
 
         {% if questionGroup.pageNumber > 1 %}
-          <a href="/short-answer/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber - 1 }}/">
+          <a href="/short-answer/{{ questionGroup.tagName }}/{{ questionGroup.pageNumber - 1 }}/" data-prev-link>
             Previous Question
           </a>
         {% else %}
@@ -52,5 +52,6 @@ eleventyExcludeFromCollections: true
 {% block scripts %}
   <script>
     {% include 'js/short-answer.js' %}
+    {% include 'js/update-pagination-links.js' %}
   </script>
 {% endblock %}

--- a/src/js/intercept-category-navigation.js
+++ b/src/js/intercept-category-navigation.js
@@ -1,0 +1,50 @@
+const getQuestions = async () => {
+  const response = await fetch('/questions.json');
+  const questions = await response.json();
+
+  return questions;
+};
+
+const getRelevantQuestions = (questions, category, isMultipleChoice) => {
+  return questions.filter((question) => {
+    if (!isMultipleChoice && question['Multiple Choice Only']) {
+      return false;
+    }
+
+    if (category !== 'All' && !question.Tags.some((tag) => tag === category)) {
+      return false;
+    }
+
+    return true;
+  });
+};
+
+(async () => {
+  sessionStorage.removeItem('questions');
+  sessionStorage.removeItem('questionStatus');
+  const questions = await getQuestions();
+  const links = document.querySelectorAll('.cmp-categories__link');
+
+  links.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      const relevantQuestions = getRelevantQuestions(
+        questions,
+        link.dataset.category,
+        link.dataset.type === 'Multiple Choice'
+      );
+
+      const questionOrder = Array.from(
+        { length: relevantQuestions.length },
+        (_item, index) => `${link.dataset.baseLink}${index + 1}/`
+      ).sort(() => (Math.random() > 0.5 ? 1 : -1));
+
+      sessionStorage.setItem('questions', JSON.stringify(questionOrder));
+
+      sessionStorage.setItem('currentQuestionIndex', '0');
+
+      window.location.href = questionOrder[0];
+    });
+  });
+})();

--- a/src/js/update-pagination-links.js
+++ b/src/js/update-pagination-links.js
@@ -1,0 +1,92 @@
+const removeLink = (selector) => {
+  const span = document.createElement('span');
+  const link = document.querySelector(selector);
+  link?.replaceWith(span);
+};
+
+const setLinkHref = (selector, url, linkText) => {
+  const link = document.querySelector(selector);
+
+  if (link) {
+    link.setAttribute('href', url);
+  } else {
+    const span = document.querySelector('.cmp-pagination span');
+    const a = document.createElement('a');
+    a.setAttribute('href', url);
+    a.setAttribute(selector.replace('[', '').replace(']', ''), '');
+    a.innerHTML = linkText;
+    span?.replaceWith(a);
+  }
+};
+
+const updatePreviousLink = (questions, currentQuestionIndex) => {
+  if (currentQuestionIndex <= 0) {
+    removeLink('[data-prev-link]');
+  } else {
+    setLinkHref(
+      '[data-prev-link]',
+      questions[currentQuestionIndex - 1],
+      'Previous Question'
+    );
+  }
+};
+
+const updateNextLink = (questions, currentQuestionIndex) => {
+  if (currentQuestionIndex >= questions.length - 1) {
+    removeLink('[data-next-link]');
+  } else {
+    setLinkHref(
+      '[data-next-link]',
+      questions[currentQuestionIndex + 1],
+      'Next Question'
+    );
+  }
+};
+
+const updateQuestionNumber = (currentQuestionIndex) => {
+  const currentQuestionElement = document.querySelector(
+    '[data-question-number]'
+  );
+
+  if (currentQuestionElement) {
+    currentQuestionElement.innerHTML = currentQuestionIndex + 1;
+  }
+};
+
+(() => {
+  const questionsRaw = sessionStorage.getItem('questions');
+  const currentQuestionIndexRaw = sessionStorage.getItem(
+    'currentQuestionIndex'
+  );
+
+  if (questionsRaw && currentQuestionIndexRaw) {
+    const questions = JSON.parse(questionsRaw);
+    const currentQuestionIndex = Number.parseInt(currentQuestionIndexRaw, 10);
+
+    updatePreviousLink(questions, currentQuestionIndex);
+    updateNextLink(questions, currentQuestionIndex);
+    updateQuestionNumber(currentQuestionIndex);
+
+    const previousLink = document.querySelector('[data-prev-link]');
+    previousLink?.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      sessionStorage.setItem(
+        'currentQuestionIndex',
+        (currentQuestionIndex - 1).toString()
+      );
+      window.location.href = event.target.href;
+    });
+
+    const nextLink = document.querySelector('[data-next-link]');
+    nextLink?.addEventListener('click', (event) => {
+      event.preventDefault();
+
+      sessionStorage.setItem(
+        'currentQuestionIndex',
+        (currentQuestionIndex + 1).toString()
+      );
+      window.location.href = event.target.href;
+    });
+  }
+})();

--- a/src/macros/categories.njk
+++ b/src/macros/categories.njk
@@ -5,7 +5,7 @@
 
 <ul class="cmp-categories">
 	<li class="cmp-categories__item">
-		<a href="/all/{{ catdir }}/1/" class="cmp-categories__link">
+		<a href="/all/{{ catdir }}/1/" class="cmp-categories__link" data-type="{{ title }}" data-category="All" data-base-link="/all/{{ catdir }}/">
 			All Questions
 		</a>
 	</li>

--- a/src/partials/category.njk
+++ b/src/partials/category.njk
@@ -1,5 +1,5 @@
 <li class="cmp-categories__item">
-	<a href="/{{ catdir }}/{{ category | slugify }}/1/" class="cmp-categories__link">
+	<a href="/{{ catdir }}/{{ category | slugify }}/1/" class="cmp-categories__link" data-type="{{ title }}" data-category="{{ category }}" data-base-link="/{{ catdir }}/{{ category | slugify }}/">
 		{{ category }}
 	</a>
 </li>


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work uses client-side JS to keep the question order fresh by randomly sorting the questions when a user clicks on a category to start playing. The basic flow is like so:

1. User clicks on a category link
2. We intercept the click event, randomize the questions for that category and store the list of URLs in `sessionStorage` before redirecting the user to the first question in the random order
3. We update pagination links and the displayed question number on page load for each question so it looks like the user is on Question 1 to start, even if it's really the 15th page
4. We intercept pagination link clicks to update the user's index in the random question order, so that when we load the next question, we can update the links and question number accordingly

If JS is disabled or fails, this will fall back to navigating through the questions in build-time order, so this is should be a relatively safe progressive enhancement.

Closes #22 

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
6. Pull down this branch
7. Run `npm start`
8. Navigate to the home page and select a category with a large number of questions (or all questions)
9. Click through the pages, ensuring that the Previous/Next Question links navigate consistently (i.e. you see the same questions when you click through backwards and forwards) and that the "Question n of m" text reflects the number of questions you've seen, not the number in the URL
10. Go back to the home page and pick the same category again, confirming that you get a different question order
<!-- Add additional validation steps here -->
