### PR TITLE
feat: allow users to set max number of questions

### DIFF
--- a/src/css/components/_form.scss
+++ b/src/css/components/_form.scss
@@ -1,12 +1,14 @@
-.cmp-inline-form {
-  display: flex;
-  flex-flow: row wrap;
-  gap: 1rem;
-  align-items: end;
-  margin-block: 1.5rem;
+.cmp-form {
+  &--inline {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 1rem;
+    align-items: end;
+    margin-block: 1.5rem;
 
-  > :first-child {
-    flex-grow: 1;
+    > :first-child {
+      flex-grow: 1;
+    }
   }
 
   &__label {
@@ -24,5 +26,15 @@
     font-size: clamp(1rem, 1rem + 1vw, 2rem);
     border: 0.125rem solid var(--text-color);
     border-radius: 0.25rem;
+
+    &--mini {
+      max-width: 8ch;
+    }
+  }
+
+  &__description {
+    font-size: clamp(0.875rem, 0.875rem + 0.5vw, 1.125rem);
+    margin-block-start: 0;
+    max-width: 70ch;
   }
 }

--- a/src/css/components/_stack.scss
+++ b/src/css/components/_stack.scss
@@ -2,4 +2,8 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+
+  &--large {
+    gap: 2rem;
+  }
 }

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -79,7 +79,7 @@
 @forward 'components/multiple-choice';
 @forward 'components/game-header';
 @forward 'components/explanation-section';
-@forward 'components/inline-form';
+@forward 'components/form';
 @forward 'components/button';
 @forward 'components/checkbox';
 

--- a/src/js/game-settings.js
+++ b/src/js/game-settings.js
@@ -24,9 +24,9 @@ const updateQuestionCounts = async () => {
 const handleSelectionChange = async () => {
 	const questionsForGame = await getQuestionsForGame(questions, IS_MULTIPLE_CHOICE);
 	const numberOfQuestions = questionsForGame.length;
-	const questionCountElement = document.querySelector('[data-question-total]');
-	if (questionCountElement) {
-		questionCountElement.textContent = numberOfQuestions;
+	const maxQuestionsInput = document.querySelector('#max-questions');
+	if (maxQuestionsInput) {
+		maxQuestionsInput.value = numberOfQuestions;
 	}
 };
 
@@ -42,9 +42,13 @@ const startGame = async () => {
 	sessionStorage.removeItem('questionStatus');
 
 	const questionsForGame = await getQuestionsForGame(questions, IS_MULTIPLE_CHOICE);
+	const maxQuestionsInput = document.querySelector('#max-questions');
+	const maxQuestions = Number.parseInt(maxQuestionsInput?.value, 10) || questionsForGame.length;
+
 	const questionOrder = questionsForGame
 		.map((question) => `/${GAME_TYPE}/all-questions/${question.pageNumber}/`)
-		.sort(() => (Math.random() > 0.5 ? 1 : -1));
+		.sort(() => (Math.random() > 0.5 ? 1 : -1))
+		.slice(0, maxQuestions);
 
 	sessionStorage.setItem('questions', JSON.stringify(questionOrder));
 	sessionStorage.setItem('currentQuestionIndex', '0');

--- a/src/macros/game-settings.njk
+++ b/src/macros/game-settings.njk
@@ -2,7 +2,7 @@
 	<div class="obj-width-limiter">
 		<h1>{{ title }}</h1>
 
-		<form class="cmp-stack" method="GET" action="/{{ gameType }}/all-questions/1/" data-game-settings>
+		<form class="cmp-stack cmp-stack--large" method="GET" action="/{{ gameType }}/all-questions/1/" data-game-settings>
 			<fieldset>
 				<legend>Question Categories</legend>
 				<div class="cmp-checkbox__grid">
@@ -14,6 +14,13 @@
 					{% endfor %}
 				</div>
 			</fieldset>
+			<div class="cmp-form">
+				<label for="max-questions" class="cmp-form__label">Max Questions</label>
+				<p id="max-questions-description" class="cmp-form__description">
+					Choose how many questions you want to answer this round. Some questions belong to multiple categories, but we'll only show each question once.
+				</p>
+				<input id="max-questions" type="text" class="cmp-form__input cmp-form__input--mini" aria-describedby="max-questions-description">
+			</div>
 			<div>
 				<button type="submit" class="cmp-button">Start Game (<span data-question-total>All</span> Questions)</button>
 			</div>

--- a/src/macros/game-settings.njk
+++ b/src/macros/game-settings.njk
@@ -19,10 +19,10 @@
 				<p id="max-questions-description" class="cmp-form__description">
 					Choose how many questions you want to answer this round. Some questions belong to multiple categories, but we'll only show each question once.
 				</p>
-				<input id="max-questions" type="text" class="cmp-form__input cmp-form__input--mini" aria-describedby="max-questions-description">
+				<input id="max-questions" type="text" inputmode="numeric" pattern="\d+" class="cmp-form__input cmp-form__input--mini" aria-describedby="max-questions-description">
 			</div>
 			<div>
-				<button type="submit" class="cmp-button">Start Game (<span data-question-total>All</span> Questions)</button>
+				<button type="submit" class="cmp-button">Start Game</button>
 			</div>
 		</form>
 	</div>

--- a/src/macros/short-answer.njk
+++ b/src/macros/short-answer.njk
@@ -2,12 +2,12 @@
   <div class="cmp-question">
     {{ question.Question | mdToHtml | safe }}
   </div>
-  <form id="answerForm" class="cmp-inline-form">
+  <form id="answerForm" class="cmp-form cmp-form--inline">
     <div>
-      <label for="userAnswer" class="cmp-inline-form__label">
+      <label for="userAnswer" class="cmp-form__label">
         Your Answer
       </label>
-      <input id="userAnswer" type="text" name="answer" autofill="false" autocomplete="off" class="cmp-inline-form__input">
+      <input id="userAnswer" type="text" name="answer" autofill="false" autocomplete="off" class="cmp-form__input">
     </div>
     <div>
       <button type="submit" class="cmp-button">


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This builds on the work in #179 to add more control for users over game settings. This allows users to choose the number of questions they want to answer for a given round.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Click on any of the Flash Cards, Short Answer, or Multiple Choice links on the home page to get to that game type's settings page
5. Confirm that a "Max Questions" input is shown and that its styles match the site overall
6. Confirm that the max questions input's value matches the total number of questions
7. Choose some categories and confirm that the input's value updates (accounting for the overlap in categories)
8. Start the game, confirming that it takes you through the number of questions the input indicated
9. Go back to game settings, and choose a value less than the default, and start the game
10. Confirm that it takes you through the number of questions that you specified
<!-- Add additional validation steps here -->
