### PR TITLE
feat: support setting a time limit

### DIFF
--- a/pages/flash-cards/index.njk
+++ b/pages/flash-cards/index.njk
@@ -21,14 +21,14 @@ eleventyExcludeFromCollections: true
 <div class="obj-content-width">
   <article>
     <header class="cmp-game-header">
-      <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h2>
+      <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h1>
       <h2 class="cmp-game-header__subtitle">
         {% if questionGroup.category !== 'All Questions' %}
           Category: {{ questionGroup.category }}
         {% else %}
           {{ questionGroup.question.Tags | csvList }}
         {% endif %}
-      </h1>
+      </h2>
     </header>
     {% from 'macros/flash-card.njk' import flashCard %}
     {{ flashCard(questionGroup.question) }}

--- a/pages/flash-cards/index.njk
+++ b/pages/flash-cards/index.njk
@@ -23,11 +23,14 @@ eleventyExcludeFromCollections: true
     <header class="cmp-game-header">
       <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h1>
       <h2 class="cmp-game-header__subtitle">
-        {% if questionGroup.category !== 'All Questions' %}
-          Category: {{ questionGroup.category }}
-        {% else %}
-          {{ questionGroup.question.Tags | csvList }}
-        {% endif %}
+        <span>
+          {% if questionGroup.category !== 'All Questions' %}
+            Category: {{ questionGroup.category }}
+          {% else %}
+            {{ questionGroup.question.Tags | csvList }}
+          {% endif %}
+        </span>
+        <span data-time-remaining></span>
       </h2>
     </header>
     {% from 'macros/flash-card.njk' import flashCard %}

--- a/pages/index.njk
+++ b/pages/index.njk
@@ -28,7 +28,7 @@ description: A quiz game and study tool to help those at all skill levels to lea
 			</li>
 			<li class="cmp-categories__item">
 				<a href="/flash-cards/all-questions/1/" class="cmp-categories__link cmp-categories__link--alternative" data-game-type="flash-cards">
-					Flash Cards quick start (all categories, 50 questions max)
+					Flash Cards quick start (all categories, no timer, 50 questions max)
 				</a>
 			</li>
 			<li class="cmp-categories__item">
@@ -38,7 +38,7 @@ description: A quiz game and study tool to help those at all skill levels to lea
 			</li>
 			<li class="cmp-categories__item">
 				<a href="/short-answer/all-questions/1/" class="cmp-categories__link cmp-categories__link--alternative" data-game-type="short-answer">
-					Short Answer quick start (all categories, 50 questions max)
+					Short Answer quick start (all categories, no timer, 50 questions max)
 				</a>
 			</li>
 			<li class="cmp-categories__item">
@@ -48,7 +48,7 @@ description: A quiz game and study tool to help those at all skill levels to lea
 			</li>
 			<li class="cmp-categories__item">
 				<a href="/multiple-choice/all-questions/1/" class="cmp-categories__link cmp-categories__link--alternative" data-game-type="multiple-choice">
-					Multiple Choice quick start (all categories, 50 questions max)
+					Multiple Choice quick start (all categories, no timer, 50 questions max)
 				</a>
 			</li>
 		</ul>

--- a/pages/multiple-choice/index.njk
+++ b/pages/multiple-choice/index.njk
@@ -24,11 +24,14 @@ eleventyExcludeFromCollections: true
     <header class="cmp-game-header">
       <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h1>
       <h2 class="cmp-game-header__subtitle">
-        {% if questionGroup.category !== 'All Questions' %}
-          Category: {{ questionGroup.category }}
-        {% else %}
-          {{ questionGroup.question.Tags | csvList }}
-        {% endif %}
+        <span>
+          {% if questionGroup.category !== 'All Questions' %}
+            Category: {{ questionGroup.category }}
+          {% else %}
+            {{ questionGroup.question.Tags | csvList }}
+          {% endif %}
+        </span>
+        <span data-time-remaining></span>
       </h2>
     </header>
 

--- a/pages/multiple-choice/index.njk
+++ b/pages/multiple-choice/index.njk
@@ -22,14 +22,14 @@ eleventyExcludeFromCollections: true
 <div class="obj-content-width">
   <article>
     <header class="cmp-game-header">
-      <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h2>
+      <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h1>
       <h2 class="cmp-game-header__subtitle">
         {% if questionGroup.category !== 'All Questions' %}
           Category: {{ questionGroup.category }}
         {% else %}
           {{ questionGroup.question.Tags | csvList }}
         {% endif %}
-      </h1>
+      </h2>
     </header>
 
     {% from 'macros/multiple-choice.njk' import multipleChoice %}

--- a/pages/short-answer/index.njk
+++ b/pages/short-answer/index.njk
@@ -21,14 +21,14 @@ eleventyExcludeFromCollections: true
   <div class="obj-content-width">
     <article>
       <header class="cmp-game-header">
-        <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h2>
+        <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h1>
         <h2 class="cmp-game-header__subtitle">
           {% if questionGroup.category !== 'All Questions' %}
             Category: {{ questionGroup.category }}
           {% else %}
             {{ questionGroup.question.Tags | csvList }}
           {% endif %}
-        </h1>
+        </h2>
       </header>
 
       {% from 'macros/short-answer.njk' import shortAnswer %}

--- a/pages/short-answer/index.njk
+++ b/pages/short-answer/index.njk
@@ -23,11 +23,14 @@ eleventyExcludeFromCollections: true
       <header class="cmp-game-header">
         <h1 class="cmp-game-header__title">Question <span data-question-number>{{ questionGroup.pageNumber }}</span> of <span data-question-total>{{ questionGroup.questionTotal }}</span></h1>
         <h2 class="cmp-game-header__subtitle">
-          {% if questionGroup.category !== 'All Questions' %}
-            Category: {{ questionGroup.category }}
-          {% else %}
-            {{ questionGroup.question.Tags | csvList }}
-          {% endif %}
+          <span>
+            {% if questionGroup.category !== 'All Questions' %}
+              Category: {{ questionGroup.category }}
+            {% else %}
+              {{ questionGroup.question.Tags | csvList }}
+            {% endif %}
+          </span>
+          <span data-time-remaining></span>
         </h2>
       </header>
 

--- a/src/css/components/_game-header.scss
+++ b/src/css/components/_game-header.scss
@@ -7,6 +7,10 @@
 	}
 
 	&__subtitle {
+		display: flex;
+		flex-flow: row wrap;
+		gap: 1rem;
+		justify-content: space-between;
 		margin: 0;
 		font-weight: 400;
 		font-size: clamp(1rem, var(--size) + 0.5vw, 1.5rem);

--- a/src/js/flash-cards.js
+++ b/src/js/flash-cards.js
@@ -1,3 +1,5 @@
 import { updatePaginationLinks } from './helpers/update-pagination-links';
+import { initializeTimer } from './helpers/time-remaining';
 
 updatePaginationLinks();
+initializeTimer();

--- a/src/js/game-settings.js
+++ b/src/js/game-settings.js
@@ -21,6 +21,37 @@ const updateQuestionCounts = async () => {
 	});
 };
 
+const getDurationInMinutes = (durationInSeconds) => {
+	const minutes = Math.floor(durationInSeconds / 60);
+	const remainingSeconds = durationInSeconds % 60;
+	let durationStrings = [];
+
+	if (minutes > 0) {
+		durationStrings.push(minutes === 1 ? '1 minute' : `${minutes} minutes`);
+	}
+
+	if (remainingSeconds > 0) {
+		durationStrings.push(`${remainingSeconds} seconds`);
+	}
+
+	return durationStrings.join(', ');
+};
+
+const updateDurationIndicators = (numberOfQuestions) => {
+	const durationIndicators = document.querySelectorAll('[data-duration]');
+	durationIndicators.forEach((element) => {
+		const secondsPerQuestion = Number.parseInt(element.dataset.duration, 10);
+		const totalDurationInSeconds = secondsPerQuestion * numberOfQuestions;
+
+		const durationInMinutes = getDurationInMinutes(totalDurationInSeconds);
+		if (durationInMinutes) {
+			element.textContent = `(up to ${getDurationInMinutes(totalDurationInSeconds)})`;
+		} else {
+			element.textContent = '';
+		}
+	});
+};
+
 const handleSelectionChange = async () => {
 	const questionsForGame = await getQuestionsForGame(questions, IS_MULTIPLE_CHOICE);
 	const numberOfQuestions = questionsForGame.length;
@@ -28,6 +59,8 @@ const handleSelectionChange = async () => {
 	if (maxQuestionsInput) {
 		maxQuestionsInput.value = numberOfQuestions;
 	}
+
+	updateDurationIndicators(numberOfQuestions);
 };
 
 const initializeCategorySelectionChangeListener = () => {
@@ -35,6 +68,16 @@ const initializeCategorySelectionChangeListener = () => {
 	elements.forEach((element) => {
 		element.addEventListener('change', handleSelectionChange);
 	});
+};
+
+const initializeMaxQuestionsChangeListener = () => {
+	const maxQuestionsInput = document.querySelector('#max-questions');
+	if (maxQuestionsInput) {
+		maxQuestionsInput.addEventListener('change', (event) => {
+			const numberOfQuestions = Number.parseInt(event.target.value, 10) || 0;
+			updateDurationIndicators(numberOfQuestions);
+		});
+	}
 };
 
 const startGame = async () => {
@@ -67,5 +110,6 @@ const initializeFormSubmitListener = () => {
 
 updateQuestionCounts();
 initializeCategorySelectionChangeListener();
+initializeMaxQuestionsChangeListener();
 initializeFormSubmitListener();
 handleSelectionChange();

--- a/src/js/game-settings.js
+++ b/src/js/game-settings.js
@@ -81,12 +81,14 @@ const initializeMaxQuestionsChangeListener = () => {
 };
 
 const startGame = async () => {
-	sessionStorage.removeItem('questions');
-	sessionStorage.removeItem('questionStatus');
+	sessionStorage.clear();
 
 	const questionsForGame = await getQuestionsForGame(questions, IS_MULTIPLE_CHOICE);
 	const maxQuestionsInput = document.querySelector('#max-questions');
 	const maxQuestions = Number.parseInt(maxQuestionsInput?.value, 10) || questionsForGame.length;
+	const questionTimer = document.querySelector('[name="timer"]:checked')?.value;
+	const durationInSeconds =
+		questionTimer === 'no-timer' ? null : Number.parseInt(questionTimer, 10) * maxQuestions;
 
 	const questionOrder = questionsForGame
 		.map((question) => `/${GAME_TYPE}/all-questions/${question.pageNumber}/`)
@@ -95,6 +97,11 @@ const startGame = async () => {
 
 	sessionStorage.setItem('questions', JSON.stringify(questionOrder));
 	sessionStorage.setItem('currentQuestionIndex', '0');
+	if (durationInSeconds) {
+		const now = new Date().getTime();
+		const endTime = now + 1000 * durationInSeconds;
+		sessionStorage.setItem('endTime', endTime);
+	}
 
 	window.location.href = questionOrder[0];
 };

--- a/src/js/helpers/intercept-quick-start-navigation.js
+++ b/src/js/helpers/intercept-quick-start-navigation.js
@@ -15,8 +15,7 @@ const quickStartGame = async (gameType) => {
 };
 
 export const interceptQuickStartNavigation = async () => {
-	sessionStorage.removeItem('questions');
-	sessionStorage.removeItem('questionStatus');
+	sessionStorage.clear();
 	const links = document.querySelectorAll('[data-game-type]');
 
 	links.forEach((link) => {

--- a/src/js/helpers/time-remaining.js
+++ b/src/js/helpers/time-remaining.js
@@ -1,0 +1,46 @@
+const TIME_IS_UP = 'Time is up!';
+
+const formatTimeRemaining = (timeInSeconds) => {
+	const minutes = Math.floor(timeInSeconds / 60);
+	const seconds = Math.floor(timeInSeconds) % 60;
+
+	return `${minutes < 10 ? `0${minutes}` : minutes}:${seconds < 10 ? `0${seconds}` : seconds} remaining`;
+};
+
+const getTimeRemaining = () => {
+	const endTimeString = sessionStorage.getItem('endTime');
+	if (!endTimeString) {
+		return null;
+	}
+
+	const endTime = Number.parseInt(endTimeString, 10);
+	const now = new Date().getTime();
+
+	const timeRemainingInSeconds = (endTime - now) / 1000;
+	if (timeRemainingInSeconds < 0) {
+		return TIME_IS_UP;
+	}
+
+	return formatTimeRemaining(timeRemainingInSeconds);
+};
+
+const updateTimeRemaining = () => {
+	const timeRemaining = getTimeRemaining();
+	const timeRemainingElement = document.querySelector('[data-time-remaining]');
+	if (timeRemainingElement) {
+		timeRemainingElement.textContent = timeRemaining;
+
+		if (timeRemaining !== TIME_IS_UP) {
+			requestAnimationFrame(updateTimeRemaining);
+		}
+	}
+};
+
+export const initializeTimer = () => {
+	const timeRemaining = getTimeRemaining();
+	if (timeRemaining == null) {
+		return;
+	}
+
+	requestAnimationFrame(updateTimeRemaining);
+};

--- a/src/js/multiple-choice.js
+++ b/src/js/multiple-choice.js
@@ -1,7 +1,9 @@
 import { randomizeAnswers } from './helpers/randomize-answers';
 import { updatePaginationLinks } from './helpers/update-pagination-links';
 import { initializeOptionClickListeners } from './helpers/multiple-choice-options';
+import { initializeTimer } from './helpers/time-remaining';
 
 initializeOptionClickListeners();
 randomizeAnswers();
 updatePaginationLinks();
+initializeTimer();

--- a/src/js/short-answer.js
+++ b/src/js/short-answer.js
@@ -1,5 +1,7 @@
 import { initializeAnswerFormListener } from './helpers/short-answer-form';
 import { updatePaginationLinks } from './helpers/update-pagination-links';
+import { initializeTimer } from './helpers/time-remaining';
 
 initializeAnswerFormListener();
 updatePaginationLinks();
+initializeTimer();

--- a/src/macros/game-settings.njk
+++ b/src/macros/game-settings.njk
@@ -21,6 +21,27 @@
 				</p>
 				<input id="max-questions" type="text" inputmode="numeric" pattern="\d+" class="cmp-form__input cmp-form__input--mini" aria-describedby="max-questions-description">
 			</div>
+			<fieldset>
+				<legend>Question Timer</legend>
+				<div class="cmp-stack">
+					<div class="cmp-checkbox__wrapper">
+						<input id="no-timer" type="radio" name="timer" value="no-timer" checked class="cmp-checkbox__input">
+						<label for="no-timer">No Timer</label>
+					</div>
+					<div class="cmp-checkbox__wrapper">
+						<input id="15-seconds" type="radio" name="timer" value="15-seconds" class="cmp-checkbox__input">
+						<label for="15-seconds">15 seconds <span data-duration="15"></span></label>
+					</div>
+					<div class="cmp-checkbox__wrapper">
+						<input id="30-seconds" type="radio" name="timer" value="30-seconds" class="cmp-checkbox__input">
+						<label for="30-seconds">30 seconds <span data-duration="30"></span></label>
+					</div>
+					<div class="cmp-checkbox__wrapper">
+						<input id="60-seconds" type="radio" name="timer" value="60-seconds" class="cmp-checkbox__input">
+						<label for="60-seconds">60 seconds <span data-duration="60"></span></label>
+					</div>
+				</div>
+			</fieldset>
 			<div>
 				<button type="submit" class="cmp-button">Start Game</button>
 			</div>

--- a/src/macros/game-settings.njk
+++ b/src/macros/game-settings.njk
@@ -29,15 +29,15 @@
 						<label for="no-timer">No Timer</label>
 					</div>
 					<div class="cmp-checkbox__wrapper">
-						<input id="15-seconds" type="radio" name="timer" value="15-seconds" class="cmp-checkbox__input">
+						<input id="15-seconds" type="radio" name="timer" value="15" class="cmp-checkbox__input">
 						<label for="15-seconds">15 seconds <span data-duration="15"></span></label>
 					</div>
 					<div class="cmp-checkbox__wrapper">
-						<input id="30-seconds" type="radio" name="timer" value="30-seconds" class="cmp-checkbox__input">
+						<input id="30-seconds" type="radio" name="timer" value="30" class="cmp-checkbox__input">
 						<label for="30-seconds">30 seconds <span data-duration="30"></span></label>
 					</div>
 					<div class="cmp-checkbox__wrapper">
-						<input id="60-seconds" type="radio" name="timer" value="60-seconds" class="cmp-checkbox__input">
+						<input id="60-seconds" type="radio" name="timer" value="60" class="cmp-checkbox__input">
 						<label for="60-seconds">60 seconds <span data-duration="60"></span></label>
 					</div>
 				</div>

--- a/src/macros/game-settings.njk
+++ b/src/macros/game-settings.njk
@@ -19,7 +19,7 @@
 				<p id="max-questions-description" class="cmp-form__description">
 					Choose how many questions you want to answer this round. Some questions belong to multiple categories, but we'll only show each question once.
 				</p>
-				<input id="max-questions" type="text" inputmode="numeric" pattern="\d+" class="cmp-form__input cmp-form__input--mini" aria-describedby="max-questions-description">
+				<input id="max-questions" type="text" inputmode="numeric" pattern="\d+" class="cmp-form__input cmp-form__input--mini" aria-describedby="max-questions-description" autocomplete="off" autofill="false">
 			</div>
 			<fieldset>
 				<legend>Question Timer</legend>

--- a/src/macros/game-settings.njk
+++ b/src/macros/game-settings.njk
@@ -26,7 +26,7 @@
 				<div class="cmp-stack">
 					<div class="cmp-checkbox__wrapper">
 						<input id="no-timer" type="radio" name="timer" value="no-timer" checked class="cmp-checkbox__input">
-						<label for="no-timer">No Timer</label>
+						<label for="no-timer">No timer</label>
 					</div>
 					<div class="cmp-checkbox__wrapper">
 						<input id="15-seconds" type="radio" name="timer" value="15" class="cmp-checkbox__input">


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work continues to build out the advanced functionality for customizing games, this time by adding the ability for users to set a time limit. Note that while the options are for the time per question, the timer shown is for the whole quiz, and there aren't any consequences for letting the timer run out.

I also didn't set up an ARIA live region for the timer because that would be incredibly annoying. It might be good in the future to set one up that announces when there's 1 minute remaining, 30 seconds, then 5 seconds, but since there's no downside to running out of time, that doesn't seem necessary.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Go to the game settings pages for Flash Cards, Short Answer, and Multiple Choice, confirming the following for each:
    1. There's a set of radio buttons for "Question Timer", and the total estimated time for each is accurate based on the selected number of questions
    2. When you select "No timer", the question pages do not indicate a time remaining
    3. When you select a different timer option, the question pages show the time remaining based on the total game duration, and the seconds tick down at a steady rate (as close to once per second as possible)
    4. When the timer runs out, the countdown is replaced with "Time is up!" but you can continue the game unimpeded
5. On the home page, confirm that clicking the quick start links starts the games without timers
<!-- Add additional validation steps here -->
